### PR TITLE
adjust requirements to use Elemental 4

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The module provides basic markup for each of the stylings but you have an option
 ## Requirements
 
 * SilverStripe CMS ^4.0
-* SilverStripe Elemental Blocks ^2.0 || ^3.0
+* SilverStripe Elemental Blocks ^4
 
 
 ## Installation

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "email": "petar.simic@fractas.com"
     }],
     "require": {
-        "dnadesign/silverstripe-elemental": "^2.0 || ^3.0",
+        "dnadesign/silverstripe-elemental": "^4.0",
         "silverstripe/vendor-plugin": "^1.0"
     },
     "require-dev": {},


### PR DESCRIPTION
This update is to pull in Elemental 4.0

It seems the community is tagging major versions so people can still use the old `^2.0 || ^3.0` or the version that requires `^4.0`. Not sure if you would want to add a 1.0 tag for current master and 2.0 for this version or not.