### PR TITLE
BUGFIX store key of first array element rather than value

### DIFF
--- a/src/StylingStyle.php
+++ b/src/StylingStyle.php
@@ -77,7 +77,7 @@ class StylingStyle extends DataExtension
     public function populateDefaults()
     {
         $style = $this->owner->config()->get('styles');
-        $style = reset($style);
+        $style = array_key_first($style);
 
         $this->owner->Style = $style;
 


### PR DESCRIPTION
This stores update stores the key of the first style option defined in the styles config for a given element via the `StylingStyle::populateDefaults()` method.

resolves #7